### PR TITLE
Ie 7 fix

### DIFF
--- a/src/jquery.shorten.js
+++ b/src/jquery.shorten.js
@@ -8,6 +8,14 @@
  *   http://www.opensource.org/licenses/mit-license.php
  */
 
+ /* 
+ ** updated by Jeff Richardson
+ ** Updated to use strict, 
+ ** IE 7 has a "bug" It is returning underfined when trying to reference string characters in this format
+ ** content[i]. IE 7 allows content.charAt(i) This works fine in all modern browsers.
+ ** I've also added brackets where they werent added just for readability (mostly for me).
+ */
+
  (function($) {
 	$.fn.shorten = function (settings) {
 	


### PR DESCRIPTION
I am using this on a corporate site and found that some of my clients were seeing undefined placed on the screen. 

I did a lot of research and finally found the issue its an issue with IE7. IE 7 doesn't allow you to reference string characters using the []. But you can use  .charAt().

I've also updated a variable that wasn't declared as well as added some brackets that weren't added.. this was mostly for myself to help understand what was going on.

After my updates I've tested on all browsers and its working great in all conditions. 
