### PR TITLE
account for content wrapped in <p> tags & various fixes

### DIFF
--- a/src/jquery.shorten.js
+++ b/src/jquery.shorten.js
@@ -1,7 +1,7 @@
 ﻿/*
- * jQuery Shorten plugin 1.0.0
+ * jQuery Shorten plugin 1.1.0
  *
- * Copyright (c) 2013 Viral Patel
+ * Copyright (c) 2014 Viral Patel
  * http://viralpatel.net
  *
  * Licensed under the MIT license:
@@ -20,11 +20,11 @@
     $.fn.shorten = function (settings) {
 
     "use strict";
-	    if ($(this).data('jquery.shorten')){
-	    	return false;
-		}
-		$(this).data('jquery.shorten', true);
-		
+        if ($(this).data('jquery.shorten')){
+            return false;
+        }
+        $(this).data('jquery.shorten', true);
+        
         var config = {
             showChars: 100,
             ellipsesText: "...",
@@ -124,15 +124,16 @@
                         }
                     }
                 }
-                c = bag;
+                c = $('<div/>').html(bag + '<span class="ellip">' + config.ellipsesText + '</span>').html();
             }
 
-            var html = '<span class="shortcontent">' + c + '&nbsp;' + config.ellipsesText +
-                '</span><span class="allcontent">' + content +
-                '</span>&nbsp;&nbsp;<span><a href="javascript://nop/" class="morelink">' + config.moreText + '</a></span>';
+            var html = '<div class="shortcontent">' + c +
+                '</div><div class="allcontent">' + content +
+                '</div><span><a href="javascript://nop/" class="morelink">' + config.moreText + '</a></span>';
 
             $this.html(html);
-            $this.find(".allcontent").hide(); // Esconde el contenido completo para todos los textos
+            $this.find(".allcontent").hide(); // Hide all text
+            $('.shortcontent p:last', $this).css('margin-bottom',0); //Remove bottom margin on last paragraph as it's likely shortened
         }
     });
 


### PR DESCRIPTION
I found this plugin incredibly useful, until the content I was trying to shorten was user-generated from a wysiwyg. Most content gets wrapped in `<p>` tags, so it's not just 'floating.' This caused the plugin to break, as it didn't know how to properly handle them, as they were **not** tags _within_ the text to be truncated, but rather _wrapping_ the entirety of the content.

This pull request does a few things:
1. Update the copyright to 2014
2. use `<div>` tags for the `shortcontent` and `allcontent` wrappers (better semantically, as `<p>` tags within `<span>` tags is... weird)
3. integrates issue #7 that @henrythewasp addressed
4. removes bottom margin from last `<p>` tag in shortcontent (so it actually appears cut off)
5. wraps ellipses text in a `<span>` with a class of `ellip` so you can style

If anyone has a better approach to account for `<p>` tags and other wrapping elements, share em in the comments.
