### PR TITLE
Set a minimum length of the hidden text.

### DIFF
--- a/src/jquery.shorten.js
+++ b/src/jquery.shorten.js
@@ -22,6 +22,7 @@
 
         var config = {
             showChars: 100,
+            minHideChars: 10,
             ellipsesText: "...",
             moreText: "more",
             lessText: "less",
@@ -65,7 +66,7 @@
 
             var content = $this.html();
             var contentlen = $this.text().length;
-            if (contentlen > config.showChars) {
+            if (contentlen > config.showChars + config.minHideChars) {
                 var c = content.substr(0, config.showChars);
                 if (c.indexOf('<') >= 0) // If there's HTML don't want to cut it
                 {


### PR DESCRIPTION
Often, it does not make sense to hide 2 or 3 characters. In this cases, one prefer to show the entire text (102 chars), rather then 100 chars + the more tag.
I solved this problem by just inserting a new configuration variable - minHideChars - and test the length of the string (line:69) against "config.showChars + config.minHideChars", rather than just config.showChars.

Hope it helps others too!